### PR TITLE
Drop support for Node v0.10

### DIFF
--- a/templates/$package.json
+++ b/templates/$package.json
@@ -14,7 +14,7 @@ rename:
     "url": "https://github.com/<%= ask('owner') %>/<%= ask('name') %>/issues"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "license": "<%= ask('license', {default: 'MIT'}) %>",
   "scripts": {

--- a/templates/dev.json
+++ b/templates/dev.json
@@ -15,7 +15,7 @@ rename:
     "url": "https://github.com/fake/dev-<%= date('YYYY-MM-DD-mm-ss') %>/issues"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Support for Node v0.10 was dropped yesterday.

See [LTS schedule](https://github.com/nodejs/LTS#lts-schedule) and [this tweet](https://twitter.com/nodejs/status/793524310979833857).